### PR TITLE
Fix error when queries have wildcard at beginning of path selector

### DIFF
--- a/src/dalmatiner_connection.erl
+++ b/src/dalmatiner_connection.erl
@@ -126,6 +126,10 @@ handle_call({list, Bucket}, _From, State) ->
             end
     end;
 
+handle_call({list, Bucket, <<>>}, _From, State = #state{connection = C}) ->
+    {ok, Ms, C1} = ddb_tcp:list(Bucket, C),
+    {reply, {ok, Ms}, State#state{connection = C1}};
+
 handle_call({list, Bucket, Prefix}, _From, State = #state{connection = C}) ->
     {ok, Ms, C1} = ddb_tcp:list(Bucket, Prefix, C),
     {reply, {ok, Ms}, State#state{connection = C1}};


### PR DESCRIPTION
Right now runing query `SELECT avg(*.'b'.'c' BUCKET x) LAST 60s` is throwing error.

Following patch fixes handling call to list metrics with empty prefix.
