### PR TITLE
Fix a problem with escaping \ in metric parts

### DIFF
--- a/src/dql_lexer.xrl
+++ b/src/dql_lexer.xrl
@@ -7,10 +7,8 @@ Sign    = [\-+]?
 Digit   = [0-9]
 Float   = {Digit}+\.{Digit}+([eE][-+]?[0-9]+)?
 
-PART    = '(\\.|[^\'])+'
-%'% damn you syntax highlighter
-DATE    = "(\\.|[^\"])+"
-%"% damn you syntax highlighter
+PART    = '(\\.|[^\'\\])+'
+DATE    = "(\\.|[^\"\\])+"
 MET     = {PART}(\.{PART})+
 S       = [A-Za-z][A-Za-z0-9_@-]*
 WS      = ([\000-\s]|%.*)


### PR DESCRIPTION
This solves error with metrics like 'disk'.'c:\'
