### PR TITLE
Extract steps in sepperate modules

### DIFF
--- a/src/dqe_resolver.erl
+++ b/src/dqe_resolver.erl
@@ -1,0 +1,123 @@
+%%%-------------------------------------------------------------------
+%%% @author Heinz Nikolaus Gies <heinz@project-fifo.net>
+%%% @copyright (C) 2016, Heinz Nikolaus Gies
+%%% @doc
+%%% Function resolver logic
+%%% @end
+%%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
+%%%-------------------------------------------------------------------
+-module(dqe_resolver).
+-export([resolve/1]).
+
+resolve(Qs) ->
+    resolve_functions(Qs, []).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Resolves functions based on their parameter types
+%% @end
+%%--------------------------------------------------------------------
+resolve_functions(#{op := named, args := [N, Q], return := undefined}) ->
+    case resolve_functions(Q) of
+        {ok, R = #{return := T}} ->
+            {ok, #{
+               op => named,
+               args => [N, R],
+               signature => [string, T],
+               return => T
+              }
+            };
+        E ->
+            E
+    end;
+
+resolve_functions(#{op := timeshift, args := [S, Q]}) ->
+    case resolve_functions(Q) of
+        {ok, R = #{return := T}} ->
+            {ok, #{
+               op => timeshift,
+               args => [S, R],
+               signature => [integer, T],
+               return => T
+              }
+            };
+        E ->
+            E
+    end;
+
+resolve_functions(#{op := fcall, args := #{name   := Function,
+                                           inputs := Args}}) ->
+    case resolve_functions(Args, []) of
+        {ok, Args1} ->
+            %% Determine the type of each argument
+            Types = [T || #{return := T} <- Args1],
+            %% Decide wather an argument is a constant (passed to init)
+            %% or a nested function
+            Args2 = [{C, is_constant(T)} || C = #{return := T} <- Args1],
+            Constants = [C || {C, true} <- Args2],
+            Inputs = [C || {C, false} <- Args2],
+            %% Lookup if we know a function with the given types
+            case dqe_fun:lookup(Function, Types) of
+                %% If we find a function that does not take a
+                %% list of sub functions we know this is a normal
+                %%aggregate.
+                {ok,{{_, _, none}, ReturnType, FunMod}} ->
+                    FArgs = #{name      => Function,
+                              orig_args => Args,
+                              mod       => FunMod,
+                              inputs    => Inputs,
+                              constants => Constants},
+                    {ok, #{
+                       op => fcall,
+                       args => FArgs,
+                       signature => Types,
+                       return => ReturnType
+                      }};
+                %% If we find one that takes a list of sub functions
+                %% we know it is a combinator function.
+                {ok,{{_, _, _}, ReturnType, FunMod}} ->
+                    FArgs = #{name      => Function,
+                              orig_args => Args,
+                              mod       => FunMod,
+                              inputs    => Inputs,
+                              constants => Constants},
+                    {ok, #{
+                       op => combine,
+                       args => FArgs,
+                       signature => Types,
+                       return => ReturnType
+                      }};
+                {error, not_found} ->
+                    {error, {not_found, Function, Types}}
+            end;
+        E ->
+            E
+    end;
+%% Thse are constatns, we don't need to resolve any further.
+resolve_functions(N) when is_integer(N) ->
+    {ok, #{op => integer, args => [N], return => integer}};
+resolve_functions(N) when is_float(N) ->
+    {ok, #{op => float, args => [N], return => float}};
+resolve_functions(#{} = R) ->
+    {ok, R}.
+
+resolve_functions([], Acc) ->
+    {ok, lists:reverse(Acc)};
+resolve_functions([A | R], Acc) ->
+    case resolve_functions(A) of
+        {ok, T} ->
+            resolve_functions(R, [T | Acc]);
+        E ->
+            E
+    end.
+
+
+%%--------------------------------------------------------------------
+%% @doc Determines if a type is a constant or sub function.
+%% @end
+%%--------------------------------------------------------------------
+is_constant(metric) -> false;
+is_constant(metric_list) -> false;
+is_constant(histogram) -> false;
+is_constant(histogram_list) -> false;
+is_constant(_) -> true.

--- a/src/dql.erl
+++ b/src/dql.erl
@@ -133,8 +133,7 @@ flatten_step(Qs, T) ->
                     {'ok',[query_stmt()], pos_integer()}.
 expand(Qs, T) ->
     Qs1 = dql_expand:expand(Qs),
-    Qs2 = lists:flatten(Qs1),
-    get_resolution(Qs2, T).
+    get_resolution(Qs1, T).
 
 %%--------------------------------------------------------------------
 %% @private

--- a/src/dql.erl
+++ b/src/dql.erl
@@ -104,7 +104,7 @@ expand_aliases(Qs, Aliases, T) ->
                      {error, term()} |
                      {ok, [query_stmt()], pos_integer()}.
 resolve_query_functions(Qs, T) ->
-    case resolve_functions(Qs, []) of
+    case dqe_resolver:resolve(Qs) of
         {ok, Qs1} ->
             flatten_step(Qs1, T);
         E ->
@@ -274,115 +274,6 @@ get_resolution_fn(_, {error, resolution_conflict}) ->
     {error, resolution_conflict}.
 
 
-%%--------------------------------------------------------------------
-%% @private
-%% @doc Resolves functions based on their parameter types
-%% @end
-%%--------------------------------------------------------------------
-resolve_functions(#{op := named, args := [N, Q], return := undefined}) ->
-    case resolve_functions(Q) of
-        {ok, R = #{return := T}} ->
-            {ok, #{
-               op => named,
-               args => [N, R],
-               signature => [string, T],
-               return => T
-              }
-            };
-        E ->
-            E
-    end;
-
-resolve_functions(#{op := timeshift, args := [S, Q]}) ->
-    case resolve_functions(Q) of
-        {ok, R = #{return := T}} ->
-            {ok, #{
-               op => timeshift,
-               args => [S, R],
-               signature => [integer, T],
-               return => T
-              }
-            };
-        E ->
-            E
-    end;
-
-resolve_functions(#{op := fcall, args := #{name   := Function,
-                                           inputs := Args}}) ->
-    case resolve_functions(Args, []) of
-        {ok, Args1} ->
-            %% Determine the type of each argument
-            Types = [T || #{return := T} <- Args1],
-            %% Decide wather an argument is a constant (passed to init)
-            %% or a nested function
-            Args2 = [{C, is_constant(T)} || C = #{return := T} <- Args1],
-            Constants = [C || {C, true} <- Args2],
-            Inputs = [C || {C, false} <- Args2],
-            %% Lookup if we know a function with the given types
-            case dqe_fun:lookup(Function, Types) of
-                %% If we find a function that does not take a
-                %% list of sub functions we know this is a normal
-                %%aggregate.
-                {ok,{{_, _, none}, ReturnType, FunMod}} ->
-                    FArgs = #{name      => Function,
-                              orig_args => Args,
-                              mod       => FunMod,
-                              inputs    => Inputs,
-                              constants => Constants},
-                    {ok, #{
-                       op => fcall,
-                       args => FArgs,
-                       signature => Types,
-                       return => ReturnType
-                      }};
-                %% If we find one that takes a list of sub functions
-                %% we know it is a combinator function.
-                {ok,{{_, _, _}, ReturnType, FunMod}} ->
-                    FArgs = #{name      => Function,
-                              orig_args => Args,
-                              mod       => FunMod,
-                              inputs    => Inputs,
-                              constants => Constants},
-                    {ok, #{
-                       op => combine,
-                       args => FArgs,
-                       signature => Types,
-                       return => ReturnType
-                      }};
-                {error, not_found} ->
-                    {error, {not_found, Function, Types}}
-            end;
-        E ->
-            E
-    end;
-%% Thse are constatns, we don't need to resolve any further.
-resolve_functions(N) when is_integer(N) ->
-    {ok, #{op => integer, args => [N], return => integer}};
-resolve_functions(N) when is_float(N) ->
-    {ok, #{op => float, args => [N], return => float}};
-resolve_functions(#{} = R) ->
-    {ok, R}.
-
-resolve_functions([], Acc) ->
-    {ok, lists:reverse(Acc)};
-resolve_functions([A | R], Acc) ->
-    case resolve_functions(A) of
-        {ok, T} ->
-            resolve_functions(R, [T | Acc]);
-        E ->
-            E
-    end.
-
-
-%%--------------------------------------------------------------------
-%% @doc Determines if a type is a constant or sub function.
-%% @end
-%%--------------------------------------------------------------------
-is_constant(metric) -> false;
-is_constant(metric_list) -> false;
-is_constant(histogram) -> false;
-is_constant(histogram_list) -> false;
-is_constant(_) -> true.
 
 %%--------------------------------------------------------------------
 %% @doc Add start and end times to a statment.

--- a/src/dql.erl
+++ b/src/dql.erl
@@ -6,7 +6,7 @@
 -endif.
 
 -export_type([query_part/0, dqe_fun/0, query_stmt/0, get_stmt/0, flat_stmt/0,
-              statement/0]).
+              statement/0, named/0, time/0]).
 
 -type time() :: #{ op => time, args => [pos_integer() | ms | s | m | h | d | w]} | pos_integer().
 
@@ -145,12 +145,11 @@ expand(Qs, T) ->
                             {'ok',[{named, binary(), flat_stmt()}],
                              pos_integer()}.
 get_resolution(Qs, T) ->
-    case lists:foldl(fun get_resolution_fn/2, {[], T, #{}}, Qs) of
+    case dql_resolution:resolve(Qs, T) of
         {error, E} ->
             {error, E};
-        {Qs1, _, _} ->
-            Qs2 = lists:reverse(Qs1),
-            propagate_resolutions(Qs2, T)
+        {ok, Qs1} ->
+            propagate_resolutions(Qs1, T)
     end.
 
 %%--------------------------------------------------------------------
@@ -159,8 +158,8 @@ get_resolution(Qs, T) ->
 %% @end
 %%--------------------------------------------------------------------
 propagate_resolutions(Qs, T) ->
-    Qs1 = [apply_times(Q) || Q <- Qs],
-    {Start, _End} = compute_se(apply_times(T, 1000), 1000),
+    Qs1 = dql_resolution:propagate(Qs),
+    Start = dql_resolution:start_time(T),
     apply_names(Qs1, Start).
 
 apply_names(Qs, Start) ->
@@ -251,239 +250,3 @@ lexer_error(Line, {illegal, E})  ->
 lexer_error(Line, E)  ->
     {error, list_to_binary(io_lib:format("Lexer error in line ~p: ~s",
                                          [Line, E]))}.
-
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc Fetch the resulution for a single sub query.
-%% @end
-%%--------------------------------------------------------------------
--spec get_resolution_fn(named(),
-                        {[named()], time(), #{}} |
-                        {error, resolution_conflict}) ->
-                               {[named()], time(), #{}} |
-                               {error,resolution_conflict}.
-get_resolution_fn(Q, {QAcc, T, #{} = RAcc}) when is_list(QAcc) ->
-    case get_times(Q, T, RAcc) of
-        {ok, Q1, RAcc1} ->
-            {[Q1 | QAcc], T, RAcc1};
-        {error, resolution_conflict} ->
-            {error, resolution_conflict}
-    end;
-get_resolution_fn(_, {error, resolution_conflict}) ->
-    {error, resolution_conflict}.
-
-
-
-%%--------------------------------------------------------------------
-%% @doc Add start and end times to a statment.
-%% @end
-%%--------------------------------------------------------------------
--spec get_times(named(), time(), #{}) ->
-                       {ok, named(), #{}} |
-                       {error, resolution_conflict}.
-get_times(O = #{op := named, args := [N, C]}, T, #{} = BucketResolutions) ->
-    case get_times_(C, T, BucketResolutions) of
-        {ok, C1, BucketResolutions1} ->
-            {ok, O#{args => [N, C1]}, BucketResolutions1};
-        E ->
-            E
-    end.
--spec get_times_(flat_stmt(), time(), #{}) ->
-                        {ok, flat_stmt(), #{}} |
-                        {error, resolution_conflict}.
-get_times_(S = #{op := timeshift, args := [Shift, C]}, T, BucketResolutions) ->
-    T1 = S#{args := [Shift, T]},
-    get_times_(C, T1, BucketResolutions);
-
-get_times_({calc, Chain,
-            {combine,
-             F = #{args := A = #{mod := FMod, constants := Cs}}, Elements}
-           }, T, #{} = BucketResolutions) ->
-    Res = lists:foldl(fun (E, {ok, Acc, #{} = BRAcc}) ->
-                              case get_times_(E, T, BRAcc) of
-                                  {ok, E1, BR1} ->
-                                      {ok, [E1 | Acc], BR1};
-                                  Error ->
-                                      Error
-                              end;
-                          (_, E) ->
-                              E
-                      end, {ok, [], BucketResolutions}, Elements),
-    case Res of
-        {ok, Elements1, #{} = BR} ->
-            Rmss = [get_resolution(E) || E <- Elements1],
-            case lists:usort(Rmss) of
-                [{ok, Rms}] ->
-                    Elements2 = lists:reverse(Elements1),
-                    Cs1 = [map_constants(C) || C <- Cs],
-                    State = FMod:init(Cs1),
-                    {Chunk, State1} = FMod:resolution(Rms, State),
-                    Rms1 = Rms * Chunk,
-                    A1 = A#{constants => Cs1, state => State1},
-                    F1 = F#{args => A1,
-                            resolution => Rms1},
-                    Comb1 = {combine, F1, Elements2},
-                    Calc1 = {calc, Chain, Comb1},
-                    {ok, apply_times(Calc1), BR};
-                _Error ->
-                    io:format("Elements: ~p~n", [Elements]),
-                    {error, resolution_conflict}
-            end;
-        {error, E} ->
-            {error, E}
-    end;
-
-get_times_({calc, Chain, Get}, T, BucketResolutions) ->
-    {ok, Get1 = #{args := A = [Rms | _]}, BucketResolutions1} =
-        bucket_resolution(Get, BucketResolutions),
-    T1 = apply_times(T, Rms),
-    {Start, Count} = compute_se(T1, Rms),
-    Calc1 = {calc, Chain, Get1#{resolution => Rms,
-                                args => [Start, Count | A]}},
-    {ok, apply_times(Calc1), BucketResolutions1}.
-
-%%--------------------------------------------------------------------
-%% @doc Look up resolution of a get statment.
-%% @end
-%%--------------------------------------------------------------------
--spec bucket_resolution(get_stmt(), #{}) ->
-                               {ok, get_stmt(), #{}}.
-bucket_resolution(O = #{args := A = [Bucket, _]}, BucketResolutions) ->
-    {Res, BR1} = case maps:get(Bucket, BucketResolutions, undefined) of
-                     undefined ->
-                         {ok, R} = get_br(Bucket),
-                         {R, maps:put(Bucket, R, BucketResolutions)};
-                     R ->
-                         {R, BucketResolutions}
-                 end,
-    {ok, O#{args => [Res | A]}, BR1}.
-
-%%--------------------------------------------------------------------
-%% @doc Fetch the resolution of a bucket from DDB
-%% @end
-%%--------------------------------------------------------------------
--spec get_br(binary()) -> {ok, pos_integer()}.
-get_br(Bucket) ->
-    ddb_connection:resolution(Bucket).
-
-%%--------------------------------------------------------------------
-%% @doc Resolves constants to their numeric representation
-%% @end
-%%--------------------------------------------------------------------
-map_constants(T = #{op := time}) ->
-    dqe_time:to_ms(T);
-map_constants(#{op := integer, args := [N]}) ->
-    N;
-map_constants(#{op := float, args := [N]}) ->
-    N;
-map_constants(E) ->
-    E.
-
-%%--------------------------------------------------------------------
-%% @doc Propagates resolution from the bottom of a call to the top.
-%% @end
-%%--------------------------------------------------------------------
-get_resolution(#{op := O, args := [_Start, _Count, Rms | _]})
-  when O =:= get;
-       O =:= sget ->
-    {ok, Rms};
-
-get_resolution({calc, [], Get}) ->
-    get_resolution(Get);
-
-get_resolution({calc, Chain, _}) ->
-    #{resolution := Rms} = lists:last(Chain),
-    {ok, Rms};
-
-get_resolution({combine, #{resolution := Rms}, _Elements}) ->
-    {ok, Rms}.
-
-
-apply_times(#{op := named, args := [N, C]}) ->
-    C1 = apply_times(C),
-    {named, N, C1};
-
-apply_times({calc, Chain, {combine, F = #{resolution := Rms}, Elements}}) ->
-    Elements1 = [apply_times(E) || E <- Elements],
-    Chain1 = time_walk_chain(Chain, Rms, []),
-    Chain2 = lists:reverse(Chain1),
-    {calc, Chain2, {combine, F, Elements1}};
-
-apply_times({calc, Chain, Get}) ->
-    {ok, Rms} = get_resolution(Get),
-    Chain1 = time_walk_chain(Chain, Rms, []),
-    Chain2 = lists:reverse(Chain1),
-    {calc, Chain2, Get}.
-
-time_walk_chain([], _Rms, Acc) ->
-    Acc;
-
-time_walk_chain([E = #{op := fcall,
-                       args := A = #{mod := FMod, constants := Cs}} | R],
-                Rms, Acc) ->
-    Cs1 = [map_constants(C) || C <- Cs],
-    State = FMod:init(Cs1),
-    {Chunk, State1} = FMod:resolution(Rms, State),
-    Rms1 = Rms * Chunk,
-    A1 = A#{constants => Cs1, state => State1},
-    time_walk_chain(R, Rms1, [E#{chunk => Chunk,
-                                 resolution => Rms1,
-                                 args => A1} | Acc]);
-
-time_walk_chain([E | R], Rms, Acc) ->
-    time_walk_chain(R, Rms, [E | Acc]).
-
-
-
-compute_se(#{ op := between, args := [S, E]}, _Rms) when E > S->
-    {S, E - S};
-compute_se(#{ op := between, args := [S, E]}, _Rms) ->
-    {E, S - E};
-compute_se(#{ op := last, args := [N]}, Rms) ->
-    NowMs = erlang:system_time(milli_seconds),
-    RelativeNow = NowMs div Rms,
-    {RelativeNow - N, N};
-
-compute_se(#{op := before, args := [E, D]}, _Rms) ->
-    {E - D, D};
-
-compute_se(#{op := timeshift, args := [Shift, T]}, Rms) ->
-    {S, D} = compute_se(T, Rms),
-    {S - Shift, D};
-
-compute_se(#{op :='after', args := [S, D]}, _Rms) ->
-    {S, D}.
-
-apply_times(#{op := last, args := [L]}, R) ->
-    #{op => last, args => [apply_times(L, R)]};
-
-apply_times(#{op := between, args := [S, E]}, R) ->
-    #{op => between, args => [apply_times(S, R), apply_times(E, R)]};
-
-apply_times(#{op := 'after', args := [S, D]}, R) ->
-    #{op => 'after', args => [apply_times(S, R), apply_times(D, R)]};
-
-apply_times(#{op := before, args := [E, D]}, R) ->
-    #{op => before, args => [apply_times(E, R), apply_times(D, R)]};
-
-apply_times(#{op := timeshift, args := [Shift, T]}, R) ->
-    T1 = apply_times(T, R),
-    S1 = apply_times(Shift, R),
-    #{op => timeshift, args => [S1, T1]};
-
-
-apply_times(N, _) when is_integer(N) ->
-    erlang:max(1, N);
-
-apply_times(now, R) ->
-    NowMs = erlang:system_time(milli_seconds),
-    erlang:max(1, NowMs div R);
-
-apply_times(#{op := ago, args := [T]}, R) ->
-    NowMs = erlang:system_time(milli_seconds),
-    erlang:min(1, (NowMs - dqe_time:to_ms(T)) div R);
-
-
-apply_times(T, R) ->
-    erlang:max(1, dqe_time:to_ms(T) div R).

--- a/src/dql.erl
+++ b/src/dql.erl
@@ -104,7 +104,7 @@ expand_aliases(Qs, Aliases, T) ->
                      {error, term()} |
                      {ok, [query_stmt()], pos_integer()}.
 resolve_query_functions(Qs, T) ->
-    case dqe_resolver:resolve(Qs) of
+    case dql_resolver:resolve(Qs) of
         {ok, Qs1} ->
             flatten_step(Qs1, T);
         E ->

--- a/src/dql.erl
+++ b/src/dql.erl
@@ -163,51 +163,8 @@ propagate_resolutions(Qs, T) ->
     apply_names(Qs1, Start).
 
 apply_names(Qs, Start) ->
-    Qs1 = [update_name(Q) || Q <- Qs],
+    Qs1 = dql_naming:update(Qs),
     {ok, Qs1, Start}.
-
-update_name({named, L, C}) when is_list(L)->
-    {Path, Gs} = extract_path_and_groupings(C),
-    Name = [update_name_element(N, Path, Gs) || N <- L],
-    {named, dql_unparse:unparse_metric(Name), C};
-
-update_name({named, _N, _C} = Q) when is_binary(_N) ->
-    Q;
-
-update_name({named, _N, _C} = Q) ->
-    io:format("Unkown named: ~p~n", [Q]),
-    Q.
-
-update_name_element({dvar, N}, _Path, Gs) ->
-    {_, Name} = lists:keyfind(N, 1, Gs),
-    Name;
-update_name_element({pvar, N}, Path, _Gs) ->
-    lists:nth(N, Path);
-update_name_element(N, _, _) ->
-    N.
-
-extract_path_and_groupings(G = #{op := get, args := [_,_,_,_,Path]})
-  when is_list(Path) ->
-    {Path, extract_groupings(G)};
-extract_path_and_groupings(G = #{op := get, args := [_,_,_,_,Path]})
-  when is_binary(Path) ->
-    {dproto:metric_to_list(Path), extract_groupings(G)};
-extract_path_and_groupings({calc, _, G}) ->
-    extract_path_and_groupings(G);
-
-%% If we find a combine we take the values of its first element
-%% for grouings all elements will have the same anyway and for
-%% pvars there is no 'right' answer so picking the first is
-%% as good as picking any other.
-extract_path_and_groupings({combine, _, [G | _]}) ->
-    extract_path_and_groupings(G).
-
-extract_groupings(#{groupings := Gs}) ->
-    Gs;
-extract_groupings(_) ->
-    [].
-
-
 
 %%%===================================================================
 %%% Internal functions

--- a/src/dql_alias.erl
+++ b/src/dql_alias.erl
@@ -3,7 +3,7 @@
 -export([expand/2]).
 
 %%--------------------------------------------------------------------
-%% @doc Expand aliases in all query parts by replacing them with 
+%% @doc Expand aliases in all query parts by replacing them with
 %% actual selectors
 %% @end
 %%--------------------------------------------------------------------
@@ -29,8 +29,8 @@ expand(Qs, Aliases) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec resolve([dql:statement()], gb_trees:tree()) ->
-                        {error, term()} |
-                        {ok, [dql:statement()]}.
+                     {error, term()} |
+                     {ok, [dql:statement()]}.
 resolve(Qs, Aliases) ->
     %%{QQ, _AliasesQ} =
     R = lists:foldl(fun(_, {error, _} = E) ->
@@ -56,7 +56,7 @@ resolve(Qs, Aliases) ->
 %% @doc Resolves alias in a statement
 %% @end
 %%--------------------------------------------------------------------
--spec resolve_statement(dql:statement(), gb_trees:tree()) -> 
+-spec resolve_statement(dql:statement(), gb_trees:tree()) ->
                                {error, term()} |
                                {term(), gb_trees:tree()}.
 resolve_statement(O = #{op  := fcall,

--- a/src/dql_alias.erl
+++ b/src/dql_alias.erl
@@ -1,0 +1,70 @@
+-module(dql_alias).
+
+-export([expand/2]).
+
+%%--------------------------------------------------------------------
+%% @doc Expand aliases in all query parts by replacing them with 
+%% actual selectors
+%% @end
+%%--------------------------------------------------------------------
+-spec expand([dql:statement()], [term()]) ->
+                    {error, term()} |
+                    {ok, [dql:statement()]}.
+expand(Qs, Aliases) ->
+    AliasesF =
+        lists:foldl(fun({alias, Alias, Res}, AAcc) ->
+                            gb_trees:enter(Alias, Res, AAcc)
+                    end, gb_trees:empty(), Aliases),
+    dqe_lib:pdebug('parse', "Aliases resolved.", []),
+    resolve(Qs, AliasesF).
+
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Resolves the aliases.
+%% @end
+%%--------------------------------------------------------------------
+-spec resolve([dql:statement()], gb_trees:tree()) ->
+                        {error, term()} |
+                        {ok, [dql:statement()]}.
+resolve(Qs, Aliases) ->
+    {QQ, _AliasesQ} =
+        lists:foldl(fun(Q, {QAcc, AAcc}) ->
+                            {Q1, A1} = resolve_statement(Q, AAcc),
+                            {[Q1 | QAcc], A1}
+                    end, {[], Aliases}, Qs),
+    dqe_lib:pdebug('parse', "Preprocessor done.", []),
+    {ok, lists:reverse(QQ)}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Resolves alias in a statement
+%% @end
+%%--------------------------------------------------------------------
+-spec resolve_statement(dql:statement(), gb_trees:tree()) -> 
+                               {error, term()} |
+                               {term(), gb_trees:tree()}.
+resolve_statement(O = #{op  := fcall,
+                        args := Args = #{inputs := Input}},
+                  Aliases) ->
+    {Input1, A1} =
+        lists:foldl(fun (Q, {QAcc, AAcc}) ->
+                            {Qx, Ax} = resolve_statement(Q, AAcc),
+                            {[Qx | QAcc], Ax}
+                    end, {[], Aliases}, Input),
+    Input2 = lists:reverse(Input1),
+    {O#{args => Args#{inputs => Input2}}, A1};
+resolve_statement(O = #{op := named, args := [N, Q]}, Aliases) ->
+    {Q1, A1} = resolve_statement(Q, Aliases),
+    {O#{args => [N, Q1]}, A1};
+resolve_statement(#{op := var, args := [V]}, Aliases) ->
+    {value, G} = gb_trees:lookup(V, Aliases),
+    {G, Aliases};
+resolve_statement(O = #{}, Aliases) ->
+    {O, Aliases};
+resolve_statement(N, A) when is_number(N)->
+    {N, A}.

--- a/src/dql_expand.erl
+++ b/src/dql_expand.erl
@@ -1,0 +1,67 @@
+%%%-------------------------------------------------------------------
+%%% @author Heinz Nikolaus Gies <heinz@project-fifo.net>
+%%% @copyright (C) 2016, Heinz Nikolaus Gies
+%%% @doc
+%%% Expand query parts
+%%% @end
+%%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
+%%%-------------------------------------------------------------------
+-module(dql_expand).
+
+-export([expand/1]).
+
+expand(Qs) ->
+    [expand_grouped(Q, []) || Q <- Qs].
+
+expand_grouped(Q = #{op := named, args := [L, S]}, Groupings) when is_list(L) ->
+    Gs = [N || {dvar, N} <- L],
+    [Q#{args => [L, S1]} || S1 <- expand_grouped(S, Gs ++  Groupings)];
+
+expand_grouped(Q = #{op := named, args := [N, S]}, Groupings) ->
+    [Q#{args => [N, S1]} || S1 <- expand_grouped(S, Groupings)];
+
+expand_grouped(Q = #{op := timeshift, args := [T, S]}, Groupings) ->
+    [Q#{args => [T, S1]} || S1 <- expand_grouped(S, Groupings)];
+
+expand_grouped({calc, Fs, Q}, Groupings) ->
+    [{calc, Fs, Q1} || Q1 <- expand_grouped(Q, Groupings)];
+
+expand_grouped({combine, F, Qs}, Groupings) ->
+    [{combine, F, lists:flatten([expand_grouped(Q, Groupings) || Q <- Qs])}];
+
+expand_grouped(Q = #{op := get}, _Groupings) ->
+    [Q];
+
+expand_grouped(Q = #{op := lookup,
+             args := [Collection, Metric, Where]}, []) ->
+    {ok, BMs} = dqe_idx:lookup({in, Collection, Metric, Where}),
+    Q1 = Q#{op := get},
+    [Q1#{args => [Bucket, Key]} || {Bucket, Key} <- BMs];
+
+expand_grouped(Q = #{op := lookup,
+             args := [Collection, Metric, Where]}, Groupings) ->
+    {ok, BMs} = dqe_idx:lookup({in, Collection, Metric, Where}, Groupings),
+    Q1 = Q#{op := get},
+    [Q1#{args => [Bucket, Key], groupings => lists:zip(Groupings, GVs)}
+     || {Bucket, Key, GVs} <- BMs];
+
+expand_grouped(Q = #{op := lookup,
+             args := [Collection, Metric]}, []) ->
+    {ok, BMs} = dqe_idx:lookup({in, Collection, Metric}),
+    Q1 = Q#{op := get},
+    [Q1#{args => [Bucket, Key]} || {Bucket, Key} <- BMs];
+
+expand_grouped(Q = #{op := lookup,
+             args := [Collection, Metric]}, Groupings) ->
+    {ok, BMs} = dqe_idx:lookup({in, Collection, Metric}, Groupings),
+    Q1 = Q#{op := get},
+    [Q1#{args => [Bucket, Key], groupings => lists:zip(Groupings, GVs)}
+     || {Bucket, Key, GVs} <- BMs];
+
+expand_grouped(Q = #{op := sget,
+             args := [Bucket, Glob]}, _Groupings) ->
+    %% Glob is in an extra list since expand is build to use one or more
+    %% globs
+    {ok, {_Bucket, Ms}} = dqe_idx:expand(Bucket, [Glob]),
+    Q1 = Q#{op := get},
+    [Q1#{args => [Bucket, Key]} || Key <- Ms].

--- a/src/dql_expand.erl
+++ b/src/dql_expand.erl
@@ -11,7 +11,7 @@
 -export([expand/1]).
 
 expand(Qs) ->
-    [expand_grouped(Q, []) || Q <- Qs].
+    lists:flatten([expand_grouped(Q, []) || Q <- Qs]).
 
 expand_grouped(Q = #{op := named, args := [L, S]}, Groupings) when is_list(L) ->
     Gs = [N || {dvar, N} <- L],

--- a/src/dql_flatten.erl
+++ b/src/dql_flatten.erl
@@ -1,0 +1,78 @@
+%%%-------------------------------------------------------------------
+%%% @author Heinz Nikolaus Gies <heinz@project-fifo.net>
+%%% @copyright (C) 2016, Heinz Nikolaus Gies
+%%% @doc
+%%% Flattens a query AST into sub parts.
+%%% @end
+%%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
+%%%-------------------------------------------------------------------
+-module(dql_flatten).
+
+-export([flatten/1]).
+
+flatten(Qs) ->
+    [flatten_(Q) || Q <- Qs].
+
+-spec flatten_(dql:dqe_fun() | dql:get_stmt()) ->
+                      #{op => named, args => [binary() | dql:flat_stmt()]}.
+flatten_(#{op := timeshift, args := [Time, Child]}) ->
+    #{args := [N, C]} = R = flatten_(Child),
+    R#{args := [N, #{op => timeshift, args => [Time, C],
+                     return => get_type(C)}]};
+flatten_(#{op := named, args := [N, Child]}) ->
+    C = flatten_(Child, []),
+    R = get_type(C),
+    #{
+       op => named,
+       args => [N, C],
+       signature => [string, R],
+       return => R
+     };
+
+flatten_(Child = #{return := R}) ->
+    N = dql_unparse:unparse(Child),
+    C = flatten_(Child, []),
+    #{
+       op => named,
+       args => [N, C],
+       signature => [string, R],
+       return => R
+     }.
+
+-spec flatten_(dql:statement(), [dql:dqe_fun()]) ->
+                     dql:flat_stmt().
+%% flatten_(#{op := timeshift, args := [_Time, Child]}, []) ->
+flatten_(F = #{op   := fcall,
+              args := Args = #{inputs := [Child]}}, Chain) ->
+    Args1 = maps:remove(inputs, Args),
+    Args2 = maps:remove(orig_args, Args1),
+    flatten_(Child, [F#{args => Args2} | Chain]);
+
+flatten_(F = #{op   := combine,
+              args := Args = #{inputs := Children}}, Chain) ->
+    Args1 = maps:remove(orig_args, Args),
+    Args2 = maps:remove(inputs, Args1),
+    Children1 = [flatten_(C, []) || C <- Children],
+    Comb = {combine, F#{args => Args2}, Children1},
+    {calc, Chain, Comb};
+
+flatten_(Get = #{op := get},
+        Chain) ->
+    {calc, Chain, Get};
+
+flatten_(Get = #{op := lookup},
+        Chain) ->
+    {calc, Chain, Get};
+
+flatten_(Get = #{op := sget},
+        Chain) ->
+    {calc, Chain, Get}.
+
+get_type(#{return := R}) ->
+    R;
+get_type({calc, [], C}) ->
+    get_type(C);
+get_type({calc, L, _}) when is_list(L) ->
+    get_type(lists:last(L));
+get_type({combine, F, _}) ->
+    get_type(F).

--- a/src/dql_naming.erl
+++ b/src/dql_naming.erl
@@ -1,0 +1,64 @@
+%%%-------------------------------------------------------------------
+%%% @author Heinz Nikolaus Gies <heinz@project-fifo.net>
+%%% @copyright (C) 2016, Heinz Nikolaus Gies
+%%% @doc
+%%% Naming related logic
+%%% @end
+%%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
+%%%-------------------------------------------------------------------
+-module(dql_naming).
+
+-export([update/1]).
+
+%%--------------------------------------------------------------------
+%% @doc Updates names for query parts.
+%% @end
+%%--------------------------------------------------------------------
+
+update(Qs) ->
+    [update_name(Q) || Q <- Qs].
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+update_name({named, L, C}) when is_list(L)->
+    {Path, Gs} = extract_path_and_groupings(C),
+    Name = [update_name_element(N, Path, Gs) || N <- L],
+    {named, dql_unparse:unparse_metric(Name), C};
+
+update_name({named, _N, _C} = Q) when is_binary(_N) ->
+    Q;
+
+update_name({named, _N, _C} = Q) ->
+    io:format("Unkown named: ~p~n", [Q]),
+    Q.
+
+update_name_element({dvar, N}, _Path, Gs) ->
+    {_, Name} = lists:keyfind(N, 1, Gs),
+    Name;
+update_name_element({pvar, N}, Path, _Gs) ->
+    lists:nth(N, Path);
+update_name_element(N, _, _) ->
+    N.
+
+extract_path_and_groupings(G = #{op := get, args := [_,_,_,_,Path]})
+  when is_list(Path) ->
+    {Path, extract_groupings(G)};
+extract_path_and_groupings(G = #{op := get, args := [_,_,_,_,Path]})
+  when is_binary(Path) ->
+    {dproto:metric_to_list(Path), extract_groupings(G)};
+extract_path_and_groupings({calc, _, G}) ->
+    extract_path_and_groupings(G);
+
+%% If we find a combine we take the values of its first element
+%% for grouings all elements will have the same anyway and for
+%% pvars there is no 'right' answer so picking the first is
+%% as good as picking any other.
+extract_path_and_groupings({combine, _, [G | _]}) ->
+    extract_path_and_groupings(G).
+
+extract_groupings(#{groupings := Gs}) ->
+    Gs;
+extract_groupings(_) ->
+    [].

--- a/src/dql_resolution.erl
+++ b/src/dql_resolution.erl
@@ -1,0 +1,283 @@
+%%%-------------------------------------------------------------------
+%%% @author Heinz Nikolaus Gies <heinz@project-fifo.net>
+%%% @copyright (C) 2016, Heinz Nikolaus Gies
+%%% @doc
+%%% Resolution related functionality
+%%% @end
+%%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
+%%%-------------------------------------------------------------------
+-module(dql_resolution).
+
+-export([resolve/2, propagate/1, start_time/1]).
+
+resolve(Qs, T) ->
+    case lists:foldl(fun get_resolution_fn/2, {[], T, #{}}, Qs) of
+        {error, E} ->
+            {error, E};
+        {Qs1, _, _} ->
+            {ok, lists:reverse(Qs1)}
+    end.
+
+
+propagate(Qs)->
+    [apply_times(Q) || Q <- Qs].
+
+
+start_time(T) ->
+    {Start, _End} = compute_se(apply_times(T, 1000), 1000),
+    Start.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Fetch the resulution for a single sub query.
+%% @end
+%%--------------------------------------------------------------------
+-spec get_resolution_fn(dql:named(),
+                        {[dql:named()], dql:time(), #{}} |
+                        {error, resolution_conflict}) ->
+                               {[dql:named()], dql:time(), #{}} |
+                               {error,resolution_conflict}.
+get_resolution_fn(Q, {QAcc, T, #{} = RAcc}) when is_list(QAcc) ->
+    case get_times(Q, T, RAcc) of
+        {ok, Q1, RAcc1} ->
+            {[Q1 | QAcc], T, RAcc1};
+        {error, resolution_conflict} ->
+            {error, resolution_conflict}
+    end;
+get_resolution_fn(_, {error, resolution_conflict}) ->
+    {error, resolution_conflict}.
+
+
+%%--------------------------------------------------------------------
+%% @doc Add start and end times to a statment.
+%% @end
+%%--------------------------------------------------------------------
+-spec get_times(dql:named(), dql:time(), #{}) ->
+                       {ok, dql:named(), #{}} |
+                       {error, resolution_conflict}.
+get_times(O = #{op := named, args := [N, C]}, T, #{} = BucketResolutions) ->
+    case get_times_(C, T, BucketResolutions) of
+        {ok, C1, BucketResolutions1} ->
+            {ok, O#{args => [N, C1]}, BucketResolutions1};
+        E ->
+            E
+    end.
+-spec get_times_(dql:flat_stmt(), dql:time(), #{}) ->
+                        {ok, dql:flat_stmt(), #{}} |
+                        {error, resolution_conflict}.
+get_times_(S = #{op := timeshift, args := [Shift, C]}, T, BucketResolutions) ->
+    T1 = S#{args := [Shift, T]},
+    get_times_(C, T1, BucketResolutions);
+
+get_times_({calc, Chain,
+            {combine,
+             F = #{args := A = #{mod := FMod, constants := Cs}}, Elements}
+           }, T, #{} = BucketResolutions) ->
+    Res = lists:foldl(fun (E, {ok, Acc, #{} = BRAcc}) ->
+                              case get_times_(E, T, BRAcc) of
+                                  {ok, E1, BR1} ->
+                                      {ok, [E1 | Acc], BR1};
+                                  Error ->
+                                      Error
+                              end;
+                          (_, E) ->
+                              E
+                      end, {ok, [], BucketResolutions}, Elements),
+    case Res of
+        {ok, Elements1, #{} = BR} ->
+            Rmss = [get_resolution(E) || E <- Elements1],
+            case lists:usort(Rmss) of
+                [{ok, Rms}] ->
+                    Elements2 = lists:reverse(Elements1),
+                    Cs1 = [map_constants(C) || C <- Cs],
+                    State = FMod:init(Cs1),
+                    {Chunk, State1} = FMod:resolution(Rms, State),
+                    Rms1 = Rms * Chunk,
+                    A1 = A#{constants => Cs1, state => State1},
+                    F1 = F#{args => A1,
+                            resolution => Rms1},
+                    Comb1 = {combine, F1, Elements2},
+                    Calc1 = {calc, Chain, Comb1},
+                    {ok, apply_times(Calc1), BR};
+                _Error ->
+                    io:format("Elements: ~p~n", [Elements]),
+                    {error, resolution_conflict}
+            end;
+        {error, E} ->
+            {error, E}
+    end;
+
+get_times_({calc, Chain, Get}, T, BucketResolutions) ->
+    {ok, Get1 = #{args := A = [Rms | _]}, BucketResolutions1} =
+        bucket_resolution(Get, BucketResolutions),
+    T1 = apply_times(T, Rms),
+    {Start, Count} = compute_se(T1, Rms),
+    Calc1 = {calc, Chain, Get1#{resolution => Rms,
+                                args => [Start, Count | A]}},
+    {ok, apply_times(Calc1), BucketResolutions1}.
+
+%%--------------------------------------------------------------------
+%% @doc Walksa  callchain and applies times to all the functions
+%% @end
+%%--------------------------------------------------------------------
+
+time_walk_chain([], _Rms, Acc) ->
+    Acc;
+
+time_walk_chain([E = #{op := fcall,
+                       args := A = #{mod := FMod, constants := Cs}} | R],
+                Rms, Acc) ->
+    Cs1 = [map_constants(C) || C <- Cs],
+    State = FMod:init(Cs1),
+    {Chunk, State1} = FMod:resolution(Rms, State),
+    Rms1 = Rms * Chunk,
+    A1 = A#{constants => Cs1, state => State1},
+    time_walk_chain(R, Rms1, [E#{chunk => Chunk,
+                                 resolution => Rms1,
+                                 args => A1} | Acc]);
+
+time_walk_chain([E | R], Rms, Acc) ->
+    time_walk_chain(R, Rms, [E | Acc]).
+
+%%--------------------------------------------------------------------
+%% @doc Resolves constants to their numeric representation
+%% @end
+%%--------------------------------------------------------------------
+map_constants(T = #{op := time}) ->
+    dqe_time:to_ms(T);
+map_constants(#{op := integer, args := [N]}) ->
+    N;
+map_constants(#{op := float, args := [N]}) ->
+    N;
+map_constants(E) ->
+    E.
+
+
+%%--------------------------------------------------------------------
+%% @doc Look up resolution of a get statment.
+%% @end
+%%--------------------------------------------------------------------
+-spec bucket_resolution(dql:get_stmt(), #{}) ->
+                               {ok, dql:get_stmt(), #{}}.
+bucket_resolution(O = #{args := A = [Bucket, _]}, BucketResolutions) ->
+    {Res, BR1} = case maps:get(Bucket, BucketResolutions, undefined) of
+                     undefined ->
+                         {ok, R} = get_br(Bucket),
+                         {R, maps:put(Bucket, R, BucketResolutions)};
+                     R ->
+                         {R, BucketResolutions}
+                 end,
+    {ok, O#{args => [Res | A]}, BR1}.
+
+%%--------------------------------------------------------------------
+%% @doc Fetch the resolution of a bucket from DDB
+%% @end
+%%--------------------------------------------------------------------
+-spec get_br(binary()) -> {ok, pos_integer()}.
+get_br(Bucket) ->
+    ddb_connection:resolution(Bucket).
+
+%%--------------------------------------------------------------------
+%% @doc Propagates resolution from the bottom of a call to the top.
+%% @end
+%%--------------------------------------------------------------------
+get_resolution(#{op := O, args := [_Start, _Count, Rms | _]})
+  when O =:= get;
+       O =:= sget ->
+    {ok, Rms};
+
+get_resolution({calc, [], Get}) ->
+    get_resolution(Get);
+
+get_resolution({calc, Chain, _}) ->
+    #{resolution := Rms} = lists:last(Chain),
+    {ok, Rms};
+
+get_resolution({combine, #{resolution := Rms}, _Elements}) ->
+    {ok, Rms}.
+
+%%--------------------------------------------------------------------
+%% @doc Compute start and endtime of a query.
+%% @end
+%%--------------------------------------------------------------------
+
+compute_se(#{ op := between, args := [S, E]}, _Rms) when E > S->
+    {S, E - S};
+compute_se(#{ op := between, args := [S, E]}, _Rms) ->
+    {E, S - E};
+compute_se(#{ op := last, args := [N]}, Rms) ->
+    NowMs = erlang:system_time(milli_seconds),
+    RelativeNow = NowMs div Rms,
+    {RelativeNow - N, N};
+
+compute_se(#{op := before, args := [E, D]}, _Rms) ->
+    {E - D, D};
+
+compute_se(#{op := timeshift, args := [Shift, T]}, Rms) ->
+    {S, D} = compute_se(T, Rms),
+    {S - Shift, D};
+
+compute_se(#{op :='after', args := [S, D]}, _Rms) ->
+    {S, D}.
+
+
+%%--------------------------------------------------------------------
+%% @doc Applies time computations to a query range
+%% @end
+%%--------------------------------------------------------------------
+
+apply_times(#{op := last, args := [L]}, R) ->
+    #{op => last, args => [apply_times(L, R)]};
+
+apply_times(#{op := between, args := [S, E]}, R) ->
+    #{op => between, args => [apply_times(S, R), apply_times(E, R)]};
+
+apply_times(#{op := 'after', args := [S, D]}, R) ->
+    #{op => 'after', args => [apply_times(S, R), apply_times(D, R)]};
+
+apply_times(#{op := before, args := [E, D]}, R) ->
+    #{op => before, args => [apply_times(E, R), apply_times(D, R)]};
+
+apply_times(#{op := timeshift, args := [Shift, T]}, R) ->
+    T1 = apply_times(T, R),
+    S1 = apply_times(Shift, R),
+    #{op => timeshift, args => [S1, T1]};
+
+
+apply_times(N, _) when is_integer(N) ->
+    erlang:max(1, N);
+
+apply_times(now, R) ->
+    NowMs = erlang:system_time(milli_seconds),
+    erlang:max(1, NowMs div R);
+
+apply_times(#{op := ago, args := [T]}, R) ->
+    NowMs = erlang:system_time(milli_seconds),
+    erlang:min(1, (NowMs - dqe_time:to_ms(T)) div R);
+
+
+apply_times(T, R) ->
+    erlang:max(1, dqe_time:to_ms(T) div R).
+
+%%--------------------------------------------------------------------
+%% @doc Applies times to parts of the query logic
+%% @end
+%%--------------------------------------------------------------------
+
+apply_times(#{op := named, args := [N, C]}) ->
+    C1 = apply_times(C),
+    {named, N, C1};
+
+apply_times({calc, Chain, {combine, F = #{resolution := Rms}, Elements}}) ->
+    Elements1 = [apply_times(E) || E <- Elements],
+    Chain1 = time_walk_chain(Chain, Rms, []),
+    Chain2 = lists:reverse(Chain1),
+    {calc, Chain2, {combine, F, Elements1}};
+
+apply_times({calc, Chain, Get}) ->
+    {ok, Rms} = get_resolution(Get),
+    Chain1 = time_walk_chain(Chain, Rms, []),
+    Chain2 = lists:reverse(Chain1),
+    {calc, Chain2, Get}.
+
+

--- a/src/dql_resolver.erl
+++ b/src/dql_resolver.erl
@@ -6,7 +6,7 @@
 %%% @end
 %%% Created :  2 Aug 2016 by Heinz Nikolaus Gies <heinz@licenser.net>
 %%%-------------------------------------------------------------------
--module(dqe_resolver).
+-module(dql_resolver).
 -export([resolve/1]).
 
 resolve(Qs) ->


### PR DESCRIPTION
A simple re-factoring to allow for more convenient usage by other applications that may want to de-construct query and investigate accessed scope.

While re-factoring this bit I have added few case statements so alias expansion function will return error if alias for variable is not defined rather than crashing. This should help with reporting user errors when they do something wrong.
