### PR TITLE
Support for neq in query predicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ current_counterexample.eqc
 rebar3.crashdump
 .rebar3
 log
+_checkouts/

--- a/eqc/qry_parser_eqc.erl
+++ b/eqc/qry_parser_eqc.erl
@@ -222,7 +222,8 @@ tag() ->
        {1,  {tag, <<>>, non_empty_binary()}}]).
 
 where_clause(S) when S =< 1 ->
-    {'=', tag(), non_empty_binary()};
+    oneof([{'=', tag(), non_empty_binary()},
+           {'!=', tag(), non_empty_binary()}]);
 where_clause(S) ->
     ?LAZY(?LET(N, choose(0, S - 1), where_clause_choice(N, S))).
 
@@ -267,7 +268,7 @@ glob_element(Size) ->
           {L, G, M}, glob(Size-1),
           {[non_empty_string() | L], ["*" | G], M})).
 
-prop_qery_parse_unparse() ->
+prop_query_parse_unparse() ->
     ?FORALL(T, select_stmt(),
             begin
                 Unparsed = dql_unparse:unparse(T),

--- a/src/dql_lexer.xrl
+++ b/src/dql_lexer.xrl
@@ -35,8 +35,8 @@ FOR     = [Ff][Oo][Rr]
 WHERE   = [Ww][Hh][Ee][Rr][Ee]
 SHIFT   = [Ss][Hh][Ii][Ff][Tt]
 BY      = [Bb][Yy]
-
-
+NOT     = [Nn][Oo][Tt]
+OP_NE   = (!=)
 
 Rules.
 {SELECT}    :   {token, {kw_select,     TokenLine}}.
@@ -57,11 +57,14 @@ Rules.
 {WHERE}     :   {token, {kw_where,      TokenLine}}.
 {SHIFT}     :   {token, {kw_shift,      TokenLine}}.
 {BY}        :   {token, {kw_by,         TokenLine}}.
+{NOT}       :   {token, {kw_not,        TokenLine}}.
+
+{OP_NE}     :   {token, {op_ne,         TokenLine}}.
 
 {TIME}      :   {token, {time,          TokenLine, a(TokenChars)}}.
 
-{Sign}{Digit}+ : {token, {integer,       TokenLine, i(TokenChars)}}.
-{Sign}{Float}  : {token, {float,         TokenLine, f(TokenChars)}}.
+{Sign}{Digit}+ : {token, {integer,      TokenLine, i(TokenChars)}}.
+{Sign}{Float}  : {token, {float,        TokenLine, f(TokenChars)}}.
 
 {PART}      :   S = strip(TokenChars,   TokenLen),
                 {token, {part,          TokenLine, b(S)}}.

--- a/src/dql_parser.yrl
+++ b/src/dql_parser.yrl
@@ -10,7 +10,7 @@ Terminals '(' ')' ',' '.' '*' '/' '=' ':'
 part  integer kw_bucket kw_select kw_last kw_as kw_from date
 kw_between kw_and kw_or kw_ago kw_now time float name
 kw_after kw_before kw_for kw_where kw_alias pvar dvar kw_shift
-kw_by.
+kw_by kw_not op_ne.
 
 %% caggr aggr derivate  float name
 %% kw_after kw_before kw_for histogram percentile avg hfun mm kw_where
@@ -133,9 +133,11 @@ mfrom -> metric kw_from bucket kw_where where : ['$3', '$1', '$5'].
 tag -> part_or_name                  : {tag, <<>>, '$1'}.
 tag -> part_or_name ':' part_or_name : {tag, '$1', '$3'}.
 
-where_part -> tag '=' part_or_name : {'=', '$1', '$3'}.
-where_part -> tag                  : {'=', '$1', <<>>}.
-where_part -> '(' where ')'        : '$2'.
+where_part -> tag '=' part_or_name    : {'=', '$1', '$3'}.
+where_part -> tag op_ne part_or_name  : {'!=', '$1', '$3'}.
+where_part -> tag kw_not part_or_name : {'!=', '$1', '$3'}.
+where_part -> tag                     : {'=', '$1', <<>>}.
+where_part -> '(' where ')'           : '$2'.
 
 where -> where_part              : '$1'.
 where -> where kw_and where_part : {'and', '$1', '$3'}.

--- a/src/dql_unparse.erl
+++ b/src/dql_unparse.erl
@@ -107,6 +107,8 @@ unparse_tag({tag, N, K}) ->
     <<"'", N/binary, "':'", K/binary, "'">>.
 unparse_where({'=', T, V}) ->
     <<(unparse_tag(T))/binary, " = '", V/binary, "'">>;
+unparse_where({'!=', T, V}) ->
+    <<(unparse_tag(T))/binary, " != '", V/binary, "'">>;
 unparse_where({'or', Clause1, Clause2}) ->
     P1 = unparse_where(Clause1),
     P2 = unparse_where(Clause2),


### PR DESCRIPTION
This is an attempt to implement support for 'not equal to' in the query predicate filtering on tag values, as described in https://github.com/dalmatinerdb/dalmatinerdb/issues/59.  The parser is extended to either allow for:
`tag != 'some_value` or `tag NOT 'some_value'`

There is [related changes](https://github.com/dalmatinerdb/dqe_idx_pg/commit/15d4a202bf298d2de326330c1a61176ad9b5cf60) to be done in the index themselves to generate the correct results.
