### PR TITLE
Add support for time type

### DIFF
--- a/eqc/qry_parser_eqc.erl
+++ b/eqc/qry_parser_eqc.erl
@@ -28,12 +28,12 @@ time_unit() ->
 
 time_type() ->
     #{op => time,
-      return => integer,
+      return => time,
       signature => [integer,time_unit],
       args => [pos_int(), time_unit()]}.
 
 aggr_range() ->
-    oneof([time_type(), pos_int()]).
+    time_type().
 
 non_empty_list(T) ->
     ?SUCHTHAT(L, list(T), L /= []).

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"ddb_connection">>,{pkg,<<"ddb_connection">>,<<"0.1.8">>},0},
  {<<"dflow">>,{pkg,<<"dflow">>,<<"0.1.5">>},0},
  {<<"dproto">>,{pkg,<<"dproto">>,<<"0.1.20">>},0},
- {<<"dqe_fun">>,{pkg,<<"dqe_fun">>,<<"0.1.9">>},0},
+ {<<"dqe_fun">>,{pkg,<<"dqe_fun">>,<<"0.1.10">>},0},
  {<<"dqe_idx">>,{pkg,<<"dqe_idx">>,<<"0.1.18">>},0},
  {<<"dqe_idx_ddb">>,{pkg,<<"dqe_idx_ddb">>,<<"0.1.14">>},0},
  {<<"dqe_idx_pg">>,{pkg,<<"dqe_idx_pg">>,<<"0.2.11">>},0},

--- a/src/dqe_avg_aggr.erl
+++ b/src/dqe_avg_aggr.erl
@@ -25,7 +25,7 @@ describe(#state{time = Time}) ->
     ["avg(", integer_to_list(Time), "ms)"].
 
 spec() ->
-    {<<"avg">>, [metric, integer], none, metric}.
+    {<<"avg">>, [metric, time], none, metric}.
 
 run([Data], S = #state{count = Count}) ->
     {mmath_aggr:avg(Data, Count), S}.

--- a/src/dqe_derivate.erl
+++ b/src/dqe_derivate.erl
@@ -28,5 +28,5 @@ run([Data], S = #state{}) ->
 
 help() ->
     <<"Calculates the derivate of a series so that v(t) = v(t - 1) - v(t). As "
-      "this looses one element of the series the first element v(0) and v(1) "
+      "this loses one element of the series the first element v(0) and v(1) "
       "are always equal.">>.

--- a/src/dqe_divide_arith.erl
+++ b/src/dqe_divide_arith.erl
@@ -31,6 +31,6 @@ run([Data], S = #state{const = Const}) ->
     {mmath_trans:divide(Data, Const), S}.
 
 help() ->
-    <<"Dividetiples  each element of the series with a constant. This is "
+    <<"Divides each element of the series with a constant. This is "
       "equivalent to the infix opperator / when the right argument is a "
       "number.">>.

--- a/src/dqe_max.erl
+++ b/src/dqe_max.erl
@@ -24,7 +24,7 @@ describe(#state{time = Time}) ->
     ["max(", integer_to_list(Time), "ms)"].
 
 spec() ->
-    {<<"max">>, [metric, integer], none, metric}.
+    {<<"max">>, [metric, time], none, metric}.
 
 run([Data], S = #state{count = Count}) ->
     {mmath_aggr:max(Data, Count), S}.

--- a/src/dqe_min.erl
+++ b/src/dqe_min.erl
@@ -23,7 +23,7 @@ describe(#state{time = Time}) ->
     ["min(", integer_to_list(Time), "ms)"].
 
 spec() ->
-    {<<"min">>, [metric, integer], none, metric}.
+    {<<"min">>, [metric, time], none, metric}.
 
 run([Data], S = #state{count = Count}) ->
     {mmath_aggr:min(Data, Count), S}.

--- a/src/dqe_mul_arith.erl
+++ b/src/dqe_mul_arith.erl
@@ -31,7 +31,7 @@ run([Data], S = #state{const = Const}) ->
     {mmath_trans:mul(Data, Const), S}.
 
 help() ->
-    <<"Multiples  each element of the series with a constant. This is "
+    <<"Multiplies each element of the series with a constant. This is "
       "equivalent to the infix opperator * when the right argument is a "
       "number.">>.
 

--- a/src/dqe_sum_aggr.erl
+++ b/src/dqe_sum_aggr.erl
@@ -24,7 +24,7 @@ describe(#state{time = Time}) ->
     ["sum(", integer_to_list(Time), "ms)"].
 
 spec() ->
-    {<<"sum">>, [metric, integer], none, metric}.
+    {<<"sum">>, [metric, time], none, metric}.
 
 run([Data], S = #state{count = Count}) ->
     {mmath_aggr:sum(Data, Count), S}.

--- a/src/dql_parser.yrl
+++ b/src/dql_parser.yrl
@@ -256,7 +256,7 @@ time(T, U) ->
       op => time,
       args => [T, U],
       signature => [integer, time_unit],
-      return => integer
+      return => time
      }.
 
 named(N, Q) ->


### PR DESCRIPTION
Aggregation functions working with a time duration no longer accept both an `integer` and a `time` representation of a time duration.  This makes it easier for users of the function table to distinguish between arithmetic and time-based funs.
