### PR TITLE
Parse float arguments to arithmetic functions

### DIFF
--- a/eqc/qry_parser_eqc.erl
+++ b/eqc/qry_parser_eqc.erl
@@ -23,6 +23,9 @@ non_empty_binary() ->
 pos_int() ->
     ?SUCHTHAT(N, int(), N > 0).
 
+pos_real() ->
+    ?SUCHTHAT(R, real(), R > 0).
+
 time_unit() ->
     oneof([ms, s, m, h, d, w]).
 
@@ -80,11 +83,18 @@ aggr_tree(Size) ->
          [
           aggr1(Q),
           aggr2(Q),
-          comb(Q)
-%%          {math, multiply, Q, pos_int()},
-%%          {math, divide, Q, pos_int()}
+          comb(Q),
+          arith(Q)
          ])).
 
+arith_fun() ->
+    oneof([<<"add">>, <<"divide">>, <<"mul">>, <<"sub">>]).
+arith_const() ->
+    oneof([pos_int(), pos_real()]).
+arith(Q) ->
+    #{op => fcall,
+      args => #{name => arith_fun(),
+                inputs => [Q, arith_const()]}}.
 
 aggr2_fun() ->
     oneof([<<"avg">>, <<"sum">>, <<"min">>, <<"max">>]).

--- a/src/dql_parser.yrl
+++ b/src/dql_parser.yrl
@@ -102,7 +102,7 @@ calculatable -> selector : '$1'.
 
 fun_arg -> int_or_time : '$1'.
 fun_arg -> math        : '$1'.
-fun_arg -> float       : '$1'.
+fun_arg -> float       : unwrap('$1').
 
 
 number -> number '+' number: '$1' + '$3'.

--- a/src/dql_unparse.erl
+++ b/src/dql_unparse.erl
@@ -66,6 +66,8 @@ unparse(now) ->
 
 unparse(N) when is_integer(N)->
     <<(integer_to_binary(N))/binary>>;
+unparse(N) when is_float(N) ->
+    <<(float_to_binary(N))/binary>>;
 
 unparse(#{op := lookup, args := [B, M]}) ->
     <<(unparse_metric(M))/binary, " FROM '", B/binary, "'">>;


### PR DESCRIPTION
For a given floating point input e.g `100.0`, the lexer would output the following token:
`{float,1,100.0}`.

The parser would not parse such a token correctly, and the parse tree would result in `function_clause` errors because the aforementioned tuple was retained.  

For an example query

```
"SELECT mul('e4e93cf0-0353-47ae-9cf3-93f676b010e3'.'base'.'network'.*.'bytes_sent' BUCKET 'e4', 100.0) AS abc BEFORE \"2016-03-08 12:33:17\" FOR 600s".
```

The parse tree looked as follows:

```
[#{args => [[<<"abc">>],
    #{args => #{inputs => [#{args => [<<"e4">>,
            [<<"e4e93cf0-0353-47ae-9cf3-93f676b010e3">>,<<"base">>,
             <<"network">>,'*',<<"bytes_sent">>]],
           op => sget,
           return => metric,
           signature => [integer,integer,integer,glob,bucket]},
         {float,1,100.0}],
        name => <<"mul">>},
      op => fcall}],
   op => named,
   return => undefined}]
```
