### PR TITLE
Align chunk sizes

### DIFF
--- a/src/dqe_divide_arith.erl
+++ b/src/dqe_divide_arith.erl
@@ -12,8 +12,8 @@
 init([Const]) when is_number(Const), Const /= 0  ->
     #state{const = Const}.
 
-chunk(#state{const = Const}) ->
-    Const * ?RDATA_SIZE.
+chunk(#state{}) ->
+    ?RDATA_SIZE.
 
 resolution(_Resolution, State) ->
     {1, State}.

--- a/src/dqe_max_trans.erl
+++ b/src/dqe_max_trans.erl
@@ -12,8 +12,8 @@
 init([Const]) when is_float(Const) ->
     #state{const = Const}.
 
-chunk(#state{const = Const}) ->
-    Const * ?RDATA_SIZE.
+chunk(#state{}) ->
+    ?RDATA_SIZE.
 
 resolution(_Resolution, State) ->
     {1, State}.

--- a/src/dqe_min_trans.erl
+++ b/src/dqe_min_trans.erl
@@ -12,8 +12,8 @@
 init([Const]) when is_float(Const) ->
     #state{const = Const}.
 
-chunk(#state{const = Const}) ->
-    Const * ?RDATA_SIZE.
+chunk(#state{}) ->
+    ?RDATA_SIZE.
 
 resolution(_Resolution, State) ->
     {1, State}.

--- a/src/dqe_mul_arith.erl
+++ b/src/dqe_mul_arith.erl
@@ -12,8 +12,8 @@
 init([Const]) when is_number(Const) ->
     #state{const = Const}.
 
-chunk(#state{const = Const}) ->
-    Const * ?RDATA_SIZE.
+chunk(#state{}) ->
+    ?RDATA_SIZE.
 
 resolution(_Resolution, State) ->
     {1, State}.

--- a/src/dqe_sub_arith.erl
+++ b/src/dqe_sub_arith.erl
@@ -12,8 +12,8 @@
 init([Const]) when is_number(Const) ->
     #state{const = Const}.
 
-chunk(#state{const = Const}) ->
-    Const * ?RDATA_SIZE.
+chunk(#state{}) ->
+    ?RDATA_SIZE.
 
 resolution(_Resolution, State) ->
     {1, State}.


### PR DESCRIPTION
Some functions do not alter the size of the series, like the aggregation functions do.  Using a constant argument to determine the chunk size does not seem like the correct thing to do for such functions.  This is especially apparent when 0 is passed as an argument.  This will result in a chunk size of zero.